### PR TITLE
fix: allow trailing commas in devcontainer.json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,8 +293,8 @@ checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
 dependencies = [
  "castaway",
  "cfg-if",
- "itoa 1.0.10",
- "ryu 1.0.17",
+ "itoa",
+ "ryu",
  "static_assertions",
 ]
 
@@ -294,6 +303,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossterm"
@@ -334,6 +352,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -437,6 +475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -563,12 +611,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
@@ -580,6 +622,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -744,6 +797,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,12 +961,6 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-
-[[package]]
-name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
@@ -909,14 +1001,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_jsonrc"
-version = "0.1.0"
+name = "serde_json"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b591e90bcce7185aa4f8c775c504456586ae0f7df49a4087a1ee4179d402b8a8"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
- "itoa 0.4.8",
- "ryu 0.2.8",
+ "itoa",
+ "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1116,6 +1219,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,10 +1305,11 @@ dependencies = [
  "env_logger",
  "hex",
  "inquire",
+ "json5",
  "log",
  "ratatui",
  "serde",
- "serde_jsonrc",
+ "serde_json",
  "url",
  "walkdir",
  "wslpath2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,8 +284,8 @@ checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
 dependencies = [
  "castaway",
  "cfg-if",
- "itoa",
- "ryu",
+ "itoa 1.0.10",
+ "ryu 1.0.17",
  "static_assertions",
 ]
 
@@ -560,6 +560,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -857,6 +863,12 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+
+[[package]]
+name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
@@ -897,13 +909,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_jsonc"
-version = "1.0.108"
+name = "serde_jsonrc"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a58154381df481a41b7536101c0daccdaf2426f244334074c4c77b89b6253a7"
+checksum = "b591e90bcce7185aa4f8c775c504456586ae0f7df49a4087a1ee4179d402b8a8"
 dependencies = [
- "itoa",
- "ryu",
+ "itoa 0.4.8",
+ "ryu 0.2.8",
  "serde",
 ]
 
@@ -1181,7 +1193,7 @@ dependencies = [
  "log",
  "ratatui",
  "serde",
- "serde_jsonc",
+ "serde_jsonrc",
  "url",
  "walkdir",
  "wslpath2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,18 +982,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inquire = "0.7.4"
 json5 = "0.4.1"
 log = "0.4.21"
 ratatui = { version = "0.26.2"}
-serde = { version = "1.0.197", features = ["derive"] }
+serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 url = "2.5.0"
 walkdir = "2.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inquire = "0.7.4"
 log = "0.4.21"
 ratatui = { version = "0.26.2"}
 serde = { version = "1.0.197", features = ["derive"] }
-serde_jsonc = { version = "1.0.108" }
+serde_jsonrc = "0.1.0"
 url = "2.5.0"
 walkdir = "2.5.0"
 wslpath2 = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ dirs = "5.0.1"
 env_logger = "0.11.3"
 hex = "0.4.3"
 inquire = "0.7.4"
+json5 = "0.4.1"
 log = "0.4.21"
 ratatui = { version = "0.26.2"}
 serde = { version = "1.0.197", features = ["derive"] }
-serde_jsonrc = "0.1.0"
+serde_json = "1.0.116"
 url = "2.5.0"
 walkdir = "2.5.0"
 wslpath2 = "0.1.1"

--- a/src/history.rs
+++ b/src/history.rs
@@ -115,7 +115,7 @@ impl Tracker {
             }
 
             let file = File::open(&path)?;
-            match serde_jsonc::from_reader::<_, History>(file) {
+            match serde_jsonrc::from_reader::<_, History>(file) {
                 Ok(history) => {
                     debug!("Imported {:?} history entries", history.len());
 
@@ -178,7 +178,7 @@ impl Tracker {
             .take(MAX_HISTORY_ENTRIES)
             .collect();
 
-        serde_jsonc::to_writer_pretty(file, &history)?;
+        serde_jsonrc::to_writer_pretty(file, &history)?;
         Ok(())
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -115,7 +115,7 @@ impl Tracker {
             }
 
             let file = File::open(&path)?;
-            match serde_jsonrc::from_reader::<_, History>(file) {
+            match serde_json::from_reader::<_, History>(file) {
                 Ok(history) => {
                     debug!("Imported {:?} history entries", history.len());
 
@@ -178,7 +178,7 @@ impl Tracker {
             .take(MAX_HISTORY_ENTRIES)
             .collect();
 
-        serde_jsonrc::to_writer_pretty(file, &history)?;
+        serde_json::to_writer_pretty(file, &history)?;
         Ok(())
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -308,3 +308,23 @@ fn run(cmd: &str, args: Vec<OsString>, dry_run: bool) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_devcontainer() {
+        let path = PathBuf::from("tests/fixtures/devcontainer.json");
+        let result = DevContainer::from_config(&path, "test");
+        assert!(result.is_ok());
+        let dev_container = result.unwrap();
+
+        assert_eq!(dev_container.config_path, path);
+        assert_eq!(dev_container.name, Some(String::from("Rust")));
+        assert_eq!(
+            dev_container.workspace_path_in_container,
+            "/workspaces/test"
+        );
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -58,10 +58,10 @@ impl DevContainer {
 
     /// Parses the dev container config file.
     /// `https://code.visualstudio.com/remote/advancedcontainers/change-default-source-mount`
-    fn parse_dev_container_config(path: &Path) -> Result<serde_jsonrc::Value> {
-        let file = std::fs::File::open(path)?;
-        let reader = std::io::BufReader::new(file);
-        let config: serde_jsonrc::Value = serde_jsonrc::from_reader(reader)
+    fn parse_dev_container_config(path: &Path) -> Result<serde_json::Value> {
+        let content = std::fs::read_to_string(path)?;
+
+        let config: serde_json::Value = json5::from_str(&content)
             .wrap_err_with(|| format!("Failed to parse json file: {path:?}"))?;
 
         debug!("Parsed dev container config: {:?}", path);
@@ -230,7 +230,7 @@ impl Workspace {
             host_path: ws_path,
             config_file: FileUriJson::new(dc_path.as_str()),
         };
-        let json = serde_jsonrc::to_string(&folder_uri)?;
+        let json = serde_json::to_string(&folder_uri)?;
 
         trace!("Folder uri JSON: {json}");
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -58,10 +58,10 @@ impl DevContainer {
 
     /// Parses the dev container config file.
     /// `https://code.visualstudio.com/remote/advancedcontainers/change-default-source-mount`
-    fn parse_dev_container_config(path: &Path) -> Result<serde_jsonc::Value> {
+    fn parse_dev_container_config(path: &Path) -> Result<serde_jsonrc::Value> {
         let file = std::fs::File::open(path)?;
         let reader = std::io::BufReader::new(file);
-        let config: serde_jsonc::Value = serde_jsonc::from_reader(reader)
+        let config: serde_jsonrc::Value = serde_jsonrc::from_reader(reader)
             .wrap_err_with(|| format!("Failed to parse json file: {path:?}"))?;
 
         debug!("Parsed dev container config: {:?}", path);
@@ -230,7 +230,7 @@ impl Workspace {
             host_path: ws_path,
             config_file: FileUriJson::new(dc_path.as_str()),
         };
-        let json = serde_jsonc::to_string(&folder_uri)?;
+        let json = serde_jsonrc::to_string(&folder_uri)?;
 
         trace!("Folder uri JSON: {json}");
 

--- a/tests/fixtures/devcontainer.json
+++ b/tests/fixtures/devcontainer.json
@@ -1,0 +1,10 @@
+// This file is used to test the deserialization of a devcontainer.json file
+{
+	// Comment to verify deserialization can handle comments
+	"name": "Rust",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-bullseye",
+	"features": {
+		// Trailing commas shouldn't break deserialization
+		"ghcr.io/guiyomh/features/just:0": {},
+	},
+}


### PR DESCRIPTION
The current version doesn't like trailing commas in `devcontainer.json` file:

```shell
$ vscli open                                                                                                     
Error:                                                                                                           
   0: Failed to parse json file: "/home/popsu/prepos/test-repo/.devcontainer/devcontainer.json"                
   1: trailing comma at line 24 column 4                                                                         
                                                                                                                 
Location:                                                                                                        
   /home/popsu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/vscli-0.2.2/src/workspace.rs:65              
                                                                                                                 
Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.                                 
Run with RUST_BACKTRACE=full to include source snippets.   
```

This PR  changes the `serde_jsonc` to  `serde_jsonrc` package allows the trailing commas.

https://docs.rs/serde_jsonrc/latest/serde_jsonrc/