### PR TITLE
feat(ui): Search/filter functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +899,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1245,6 +1284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-textarea"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c07084342a575cea919eea996b9658a358c800b03d435df581c1d7c60e065a"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1401,7 @@ dependencies = [
  "crossterm 0.28.1",
  "dirs",
  "env_logger",
+ "fuzzy-matcher",
  "hex",
  "inquire",
  "json5",
@@ -1347,7 +1409,9 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "tui-textarea",
  "url",
+ "uuid",
  "walkdir",
  "wslpath2",
 ]
@@ -1623,6 +1687,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ serde_json = "1.0.116"
 url = "2.5.0"
 walkdir = "2.5.0"
 wslpath2 = "0.1.1"
+tui-textarea = "0.6.1"
+fuzzy-matcher = "0.3.7"
+uuid = { version = "1.10.0", features = ["v4", "fast-rng", "serde"] }

--- a/src/history.rs
+++ b/src/history.rs
@@ -21,7 +21,10 @@ const MAX_HISTORY_ENTRIES: usize = 35;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry {
     /// Unique identifier for the entry
-    #[serde(default = "::uuid::Uuid::new_v4")]
+    ///
+    /// Note that this attribute is not being written back to the file when serializing. It is only
+    /// used "per session" to keep track of unique records.
+    #[serde(default = "::uuid::Uuid::new_v4", skip_serializing)]
     pub uuid: Uuid,
     /// The name of the workspace
     pub workspace_name: String,

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,6 +9,7 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
 };
+use uuid::Uuid;
 
 use crate::launch::Behavior;
 
@@ -19,6 +20,9 @@ const MAX_HISTORY_ENTRIES: usize = 35;
 /// An entry in the history
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry {
+    /// Unique identifier for the entry
+    #[serde(default = "::uuid::Uuid::new_v4")]
+    pub uuid: Uuid,
     /// The name of the workspace
     pub workspace_name: String,
     /// The name of the dev container, if it exists
@@ -91,6 +95,15 @@ impl History {
     pub fn iter(&self) -> impl Iterator<Item = &Entry> {
         self.0.iter().rev()
     }
+
+    pub fn remove_by_uuid(&mut self, uuid: Uuid) -> bool {
+        // TODO: This is not good code. It shall be improved ... later
+        if let Some(entry) = self.0.iter().find(|entry| entry.uuid == uuid).cloned() {
+            return self.0.remove(&entry);
+        }
+
+        false
+    }
 }
 
 /// Manages the history and tracks the recently used workspaces
@@ -129,9 +142,9 @@ impl Tracker {
 
                     // find a non-existent backup file
                     let new_path = (0..10_000) // Set an upper limit of filename checks.
-                    .map(|i| path.with_file_name(format!(".history_{i}.json.bak")))
-                    .find(|path| !path.exists())
-                    .unwrap_or_else(|| path.with_file_name(".history.json.bak"));
+                        .map(|i| path.with_file_name(format!(".history_{i}.json.bak")))
+                        .find(|path| !path.exists())
+                        .unwrap_or_else(|| path.with_file_name(".history.json.bak"));
 
                     fs::rename(&path, &new_path).wrap_err_with(|| {
                         format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use clap::Parser;
 use color_eyre::eyre::Result;
 use log::trace;
 use std::io::Write;
+use uuid::Uuid;
 
 use crate::history::{Entry, Tracker};
 
@@ -79,6 +80,7 @@ fn main() -> Result<()> {
 
             // Store the workspace in the history
             tracker.push(Entry {
+                uuid: Uuid::new_v4(),
                 workspace_name: ws_name,
                 dev_container_name: dev_container.as_ref().and_then(|dc| dc.name.clone()),
                 workspace_path: path.canonicalize()?,
@@ -100,6 +102,7 @@ fn main() -> Result<()> {
 
                 // Update the tracker entry
                 tracker.push(Entry {
+                    uuid: Uuid::new_v4(),
                     workspace_name: ws_name,
                     dev_container_name: dev_container.as_ref().and_then(|dc| dc.name.clone()),
                     workspace_path: entry.workspace_path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,9 +89,9 @@ fn main() -> Result<()> {
                 last_opened: Utc::now(),
             });
         }
-        opts::Commands::Recent => {
+        opts::Commands::Recent { focus } => {
             // Get workspace from user selection
-            let res = ui::start(&mut tracker)?;
+            let res = ui::start(&mut tracker, focus)?;
             if let Some(entry) = res {
                 let ws = Workspace::from_path(&entry.workspace_path)?;
                 let ws_name = ws.name.clone();

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -59,7 +59,7 @@ pub(crate) enum Commands {
     /// Opens an interactive list of recently used workspaces.
     #[clap(alias = "ui")]
     Recent {
-        #[arg(value_enum, short, long, default_value_t = Focus::Search, ignore_case = true)]
+        #[arg(value_enum, short, long, default_value_t = Focus::Select, ignore_case = true)]
         focus: Focus,
     },
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -2,7 +2,7 @@ use std::{ffi::OsString, path::PathBuf};
 
 use clap::{command, Parser, Subcommand};
 
-use crate::launch::ContainerStrategy;
+use crate::{launch::ContainerStrategy, ui::Focus};
 
 /// Main CLI arguments
 #[derive(Parser, Debug)]
@@ -58,5 +58,8 @@ pub(crate) enum Commands {
     },
     /// Opens an interactive list of recently used workspaces.
     #[clap(alias = "ui")]
-    Recent,
+    Recent {
+        #[arg(value_enum, short, long, default_value_t = Focus::Search, ignore_case = true)]
+        focus: Focus,
+    },
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,8 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use log::debug;
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use log::{debug, info, warn};
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Layout},
@@ -15,52 +16,254 @@ use ratatui::{
     Frame, Terminal,
 };
 use std::{borrow::Cow, io, rc::Rc};
+use tui_textarea::{Input, Key, TextArea};
+use uuid::Uuid;
 
 use crate::history::{Entry, History, Tracker};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Search,
+    Select,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AppAction {
+    Quit,
+    Selected(Uuid),
+    DeleteEntry(Uuid),
+    SearchUpdate(Option<String>),
+}
+
+struct TableRow {
+    entry: Entry,
+    row: Row<'static>,
+    search_score: Option<i64>,
+}
+
+impl From<Entry> for TableRow {
+    fn from(value: Entry) -> Self {
+        let cells: Vec<String> = vec![
+            value.workspace_name.to_string(),
+            value
+                .dev_container_name
+                .as_deref()
+                .unwrap_or("")
+                .to_string(),
+            value.workspace_path.to_string_lossy().to_string(),
+            value
+                .last_opened
+                .clone()
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string(),
+        ];
+        let row = Row::new(cells).height(1);
+
+        Self {
+            row,
+            entry: value,
+            search_score: Some(0),
+        }
+    }
+}
+
+struct TableData {
+    rows: Vec<TableRow>,
+
+    max_worspace_name_len: Option<usize>,
+    max_devcontainer_name_len: Option<usize>,
+}
+
+impl TableData {
+    pub const HEADER: [&'static str; 4] = ["Workspace", "Dev Container", "Path", "Last Opened"];
+
+    pub fn from_iter<I: Iterator<Item = E>, E: Into<Entry>>(iter: I) -> Self {
+        let mut this = Self {
+            rows: iter.into_iter().map(|entry| entry.into().into()).collect(),
+
+            max_devcontainer_name_len: None,
+            max_worspace_name_len: None,
+        };
+
+        // Sort by `Last Opened` to keep same logic as previous versions
+        // Inverted to have newest at the top with ASC order
+        this.rows
+            .sort_by_key(|entry| -entry.entry.last_opened.timestamp());
+
+        this.recalculate_maxes();
+
+        this
+    }
+
+    pub fn is_filtered_out(&self, uuid: Uuid) -> Option<bool> {
+        self.rows
+            .iter()
+            .find(|row| row.entry.uuid == uuid)
+            .map(|entry| entry.search_score.is_none())
+    }
+
+    fn recalculate_maxes(&mut self) {
+        self.max_worspace_name_len = self
+            .rows
+            .iter()
+            .map(|row| row.entry.workspace_name.len())
+            .max();
+
+        self.max_devcontainer_name_len = self
+            .rows
+            .iter()
+            .map(|row| row.entry.dev_container_name.as_deref().unwrap_or("").len())
+            .max();
+    }
+
+    pub fn to_rows(&self) -> Vec<Row<'static>> {
+        self.rows
+            .iter()
+            .filter(|row| row.search_score.is_some())
+            .map(|row| &row.row)
+            .cloned()
+            .collect()
+    }
+
+    pub fn apply_filter(&mut self, pattern: &str) -> bool {
+        let mut changes = false;
+
+        let matcher = SkimMatcherV2::default();
+
+        for row in &mut self.rows {
+            let new_search_score = add_num_opt(
+                add_num_opt(
+                    matcher.fuzzy_match(&row.entry.workspace_name, pattern),
+                    matcher.fuzzy_match(
+                        row.entry.dev_container_name.as_deref().unwrap_or(""),
+                        pattern,
+                    ),
+                ),
+                matcher.fuzzy_match(&row.entry.workspace_path.to_string_lossy(), pattern),
+            );
+            changes |= new_search_score != row.search_score;
+            row.search_score = new_search_score;
+        }
+
+        self.rows
+            .sort_by_key(|row| row.search_score.unwrap_or(i64::MIN));
+
+        return changes;
+    }
+
+    pub fn reset_filter(&mut self) {
+        for row in &mut self.rows {
+            row.search_score = Some(0);
+        }
+    }
+}
+
 /// The UI state
 struct UI<'a> {
-    state: TableState,
-    tracker: &'a mut Tracker,
+    mode: Mode,
+    search: TextArea<'a>,
+    table_state: TableState,
+    table_data: TableData,
 }
 
 impl<'a> UI<'a> {
     /// Create new empty state from history tracker reference
-    fn new(tracker: &'a mut Tracker) -> UI<'a> {
+    pub fn new(history: &History) -> UI<'a> {
         UI {
-            state: TableState::default(),
-            tracker,
+            // TODO: Add option for initial mode
+            mode: Mode::Search,
+            search: TextArea::default(),
+            table_state: TableState::default(),
+            table_data: TableData::from_iter(history.iter().cloned()),
         }
     }
 
     /// Select the next entry
-    pub fn next(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i >= self.tracker.history.len().saturating_sub(1) {
-                    0
-                } else {
-                    i.saturating_add(1)
-                }
-            }
-            None => 0,
-        };
-        self.state.select(Some(i));
+    pub fn select_next(&mut self) {
+        self.table_state.select_next();
     }
 
     /// Select the previous entry
-    pub fn previous(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.tracker.history.len().saturating_sub(1)
+    pub fn select_previous(&mut self) {
+        self.table_state.select_previous();
+    }
+
+    pub fn apply_filter(&mut self, pattern: Option<&str>) {
+        let pattern = pattern.unwrap_or("");
+
+        let prev_selected = self.get_selected_entry().cloned();
+
+        let update_selected = if pattern.trim().is_empty() {
+            self.reset_filter();
+            true
+        } else {
+            self.table_data.apply_filter(pattern)
+        };
+
+        if !update_selected {
+            return;
+        }
+
+        // See if selected item is still visible. If not select first, else reselect (index changed)
+        if let Some(selected) = prev_selected {
+            if self
+                .table_data
+                .is_filtered_out(selected.uuid)
+                .unwrap_or(true)
+            {
+                self.table_state.select_first();
+            } else {
+                // Update index
+                if let Some(index) = self
+                    .table_data
+                    .rows
+                    .iter()
+                    .filter(|entry| {
+                        !self
+                            .table_data
+                            .is_filtered_out(entry.entry.uuid)
+                            .unwrap_or(true)
+                    })
+                    .position(|entry| entry.entry.uuid == selected.uuid)
+                {
+                    self.table_state.select(Some(index));
                 } else {
-                    i.saturating_sub(1)
+                    self.table_state.select_first();
                 }
             }
-            None => 0,
-        };
-        self.state.select(Some(i));
+        }
+    }
+
+    pub fn reset_filter(&mut self) {
+        self.table_data.reset_filter();
+    }
+
+    fn get_selected_entry(&self) -> Option<&Entry> {
+        let idx = self.table_state.selected()?;
+        self.table_data.rows.get(idx).map(|row| &row.entry)
+    }
+
+    fn delete_by_uuid(&mut self, uuid: Uuid) -> bool {
+        if let Some(index) = self
+            .table_data
+            .rows
+            .iter()
+            .position(|entry| entry.entry.uuid == uuid)
+        {
+            self.table_data.rows.remove(index);
+            return true;
+        }
+
+        false
+    }
+
+    fn reset_selected(&mut self) {
+        self.table_state.select(Some(0));
+    }
+
+    fn resync_table(&mut self, history: &History) {
+        self.table_data = TableData::from_iter(history.iter().cloned());
+        self.reset_selected();
     }
 }
 
@@ -78,7 +281,7 @@ pub(crate) fn start(tracker: &mut Tracker) -> Result<Option<Entry>> {
     let mut terminal = Terminal::new(backend)?;
 
     // create app and run it
-    let res = run_app(&mut terminal, UI::new(tracker));
+    let res = run_app(&mut terminal, UI::new(&tracker.history), tracker);
 
     // restore terminal
     disable_raw_mode()?;
@@ -90,76 +293,206 @@ pub(crate) fn start(tracker: &mut Tracker) -> Result<Option<Entry>> {
     terminal.show_cursor()?;
     debug!("Terminal restored");
 
-    Ok(res?.and_then(|index| tracker.history.iter().nth(index).cloned()))
+    Ok(res?.and_then(|uuid| {
+        tracker
+            .history
+            .iter()
+            .find(|entry| entry.uuid == uuid)
+            .cloned()
+    }))
 }
 
 /// UI main loop
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: UI) -> io::Result<Option<usize>> {
-    app.state.select(Some(0)); // Select the most recent element by default
-
-    let mut rows: Vec<Row> = app
-        .tracker
-        .history
-        .iter()
-        .map(|item| {
-            let item = item.clone();
-            let cells: Vec<String> = vec![
-                item.workspace_name.to_string(),
-                item.dev_container_name.as_deref().unwrap_or("").to_string(),
-                item.workspace_path.to_string_lossy().to_string(),
-                item.last_opened
-                    .clone()
-                    .format("%Y-%m-%d %H:%M:%S")
-                    .to_string(),
-            ];
-            Row::new(cells).height(1)
-        })
-        .collect();
+fn run_app<B: Backend>(
+    terminal: &mut Terminal<B>,
+    mut app: UI,
+    tracker: &mut Tracker,
+) -> io::Result<Option<Uuid>> {
+    app.table_state.select(Some(0)); // Select the most recent element by default
 
     loop {
-        terminal.draw(|f| render(f, &mut app, rows.clone()))?;
+        terminal.draw(|f| render(f, &mut app))?;
 
-        if let Event::Key(key) = event::read()? {
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc | KeyCode::Backspace => return Ok(None),
-                KeyCode::Down | KeyCode::Char('j') => app.next(),
-                KeyCode::Up | KeyCode::Char('k') => app.previous(),
-                KeyCode::Enter | KeyCode::Char('o') => {
-                    if let Some(selected) = app.state.selected() {
-                        return Ok(Some(selected));
+        let input = event::read()?;
+
+        let res = match app.mode {
+            Mode::Search => handle_input_search(&mut app, input),
+            Mode::Select => handle_input_select(&mut app, input),
+        }?;
+
+        if let Some(res) = res {
+            match res {
+                AppAction::Quit => return Ok(None),
+                AppAction::Selected(selected) => return Ok(Some(selected)),
+                AppAction::DeleteEntry(uuid) => {
+                    if tracker.history.remove_by_uuid(uuid) {
+                        if !app.delete_by_uuid(uuid) {
+                            // Desync - Deleted from history but not from UI.
+                            warn!(
+                                "UI state and history state desynced during deletion - Resyncing"
+                            );
+
+                            app.resync_table(&tracker.history);
+                        }
+
+                        info!("Removed history entry `{uuid}`");
                     }
                 }
-                KeyCode::Delete | KeyCode::Char('r' | 'x') => {
-                    if let Some(selected) = app.state.selected() {
-                        let entry = app.tracker.history.iter().nth(selected).unwrap().clone();
-                        app.tracker.history.remove(&entry);
-                        rows.remove(selected);
-                    }
+                AppAction::SearchUpdate(pattern) => {
+                    app.apply_filter(pattern.as_deref());
                 }
-                _ => {}
             }
         }
     }
+}
+
+fn handle_input_select(app: &mut UI, input: Event) -> io::Result<Option<AppAction>> {
+    if let Event::Key(key) = input {
+        if key.kind != KeyEventKind::Press {
+            return Ok(None);
+        }
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc | KeyCode::Backspace => {
+                return Ok(Some(AppAction::Quit))
+            }
+            KeyCode::Down | KeyCode::Char('j') => app.select_next(),
+            KeyCode::Up | KeyCode::Char('k') => app.select_previous(),
+            KeyCode::Enter | KeyCode::Char('o') => {
+                if let Some(selected) = app.get_selected_entry() {
+                    return Ok(Some(AppAction::Selected(selected.uuid)));
+                }
+            }
+            KeyCode::Delete | KeyCode::Char('r' | 'x') => {
+                if let Some(selected) = app.get_selected_entry() {
+                    return Ok(Some(AppAction::DeleteEntry(selected.uuid)));
+                }
+            }
+            KeyCode::Tab => {
+                app.mode = Mode::Search;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(None)
+}
+
+fn handle_input_search(app: &mut UI, input: Event) -> io::Result<Option<AppAction>> {
+    match input.into() {
+        Input { key: Key::Esc, .. }
+        | Input { key: Key::Tab, .. }
+        | Input {
+            key: Key::Enter, ..
+        } => {
+            app.mode = Mode::Select;
+        }
+        input => {
+            if app.search.input(input) {
+                return Ok(Some(AppAction::SearchUpdate(
+                    app.search.lines().first().cloned(),
+                )));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Main render function
+fn render(frame: &mut Frame, app: &mut UI) {
+    // Setup crossterm UI layout & style
+    let area = Layout::default()
+        .constraints(
+            [
+                Constraint::Min(3),
+                Constraint::Percentage(100),
+                Constraint::Min(1),
+                Constraint::Min(1),
+                Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .horizontal_margin(1)
+        .split(frame.area());
+
+    // Calculate the longest workspace and dev container names
+    let longest_ws_name = app
+        .table_data
+        .max_worspace_name_len
+        .unwrap_or(20)
+        .clamp(9, 60);
+
+    let longest_dc_name = app
+        .table_data
+        .max_devcontainer_name_len
+        .unwrap_or(20)
+        .clamp(9, 60);
+
+    render_search_input(frame, app, area[0]);
+
+    // Render the main table
+    render_table(
+        frame,
+        app,
+        area[1],
+        longest_ws_name as u16,
+        longest_dc_name as u16,
+    );
+
+    let selected: Option<&Entry> = app.get_selected_entry();
+
+    // Render status area
+    let status_area: Rc<[Rect]> = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)].as_ref())
+        .split(area[2]);
+    render_status_area(frame, selected, &status_area);
+
+    // Render additional info like args and dev container path
+    render_additional_info(frame, selected, [area[3], area[4]]);
+}
+
+fn render_search_input(frame: &mut Frame, app: &mut UI, area: Rect) {
+    let style = if app.mode == Mode::Search {
+        Style::default().fg(Color::Blue)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    app.search.set_block(
+        Block::default()
+            .borders(Borders::all())
+            .title("Search")
+            .border_style(style),
+    );
+
+    frame.render_widget(&app.search, area);
 }
 
 /// Renders the main table
 fn render_table(
     frame: &mut Frame,
     app: &mut UI,
-    rows: Vec<Row>,
     area: Rect,
     longest_ws_name: u16,
     longest_dc_name: u16,
 ) {
-    let selected_style = Style::default().bg(Color::DarkGray);
-    let normal_style = Style::default().bg(Color::Blue);
-    let header_cells = ["Workspace", "Dev Container", "Path", "Last Opened"]
+    let (header_style, selected_style) = if app.mode == Mode::Select {
+        (
+            Style::default().bg(Color::Blue),
+            Style::default().bg(Color::DarkGray),
+        )
+    } else {
+        (
+            Style::default().bg(Color::DarkGray),
+            Style::default().bg(Color::DarkGray),
+        )
+    };
+
+    let header_cells = TableData::HEADER
         .iter()
         .map(|header| Cell::from(*header).style(Style::default().fg(Color::White)));
-    let header = Row::new(header_cells).style(normal_style).height(1);
+    let header = Row::new(header_cells).style(header_style).height(1);
 
     let widths = [
         Constraint::Min(longest_ws_name + 1),
@@ -168,7 +501,7 @@ fn render_table(
         Constraint::Min(20),
     ];
 
-    let table = Table::new(rows, widths)
+    let table = Table::new(app.table_data.to_rows(), widths)
         .header(header)
         .block(
             Block::default()
@@ -177,13 +510,20 @@ fn render_table(
         )
         .highlight_style(selected_style)
         .highlight_symbol("> ");
-    frame.render_stateful_widget(table, area, &mut app.state);
+    frame.render_stateful_widget(table, area, &mut app.table_state);
 }
 
 /// Renders the status area
 fn render_status_area(frame: &mut Frame, selected: Option<&Entry>, status_area: &Rc<[Rect]>) {
-    let strategy = map_or_default(selected, "-", |entry| entry.behavior.strategy.to_string());
-    let insiders = map_or_default(selected, "-", |entry| entry.behavior.insiders.to_string());
+    let strategy = selected.map_or_else(
+        || String::from("-"),
+        |entry| entry.behavior.strategy.to_string(),
+    );
+
+    let insiders = selected.map_or_else(
+        || String::from("-"),
+        |entry| entry.behavior.insiders.to_string(),
+    );
 
     let additional_info = Span::styled(
         format!("Strategy: {strategy}, Insiders: {insiders}"),
@@ -207,18 +547,23 @@ fn render_status_area(frame: &mut Frame, selected: Option<&Entry>, status_area: 
 }
 
 /// Renders additional information like args and dev container path
-fn render_additional_info(frame: &mut Frame, selected: Option<&Entry>, area: &Rc<[Rect]>) {
+fn render_additional_info(frame: &mut Frame, selected: Option<&Entry>, area: [Rect; 2]) {
     // Args
-    let args_count = map_or_default(selected, "0", |entry| entry.behavior.args.len().to_string());
-    let args = selected.map_or(String::from("-"), |entry| {
-        let converted_str: Vec<Cow<'_, str>> = entry
-            .behavior
-            .args
-            .iter()
-            .map(|arg| arg.to_string_lossy())
-            .collect();
-        converted_str.join(", ")
-    });
+
+    let args_count = selected.map_or(0, |entry| entry.behavior.args.len());
+
+    let args = selected.map_or_else(
+        || String::from("-"),
+        |entry| {
+            let converted_str: Vec<Cow<'_, str>> = entry
+                .behavior
+                .args
+                .iter()
+                .map(|arg| arg.to_string_lossy())
+                .collect();
+            converted_str.join(", ")
+        },
+    );
 
     let args_info = Span::styled(
         format!("Args ({args_count}): {args}"),
@@ -227,7 +572,7 @@ fn render_additional_info(frame: &mut Frame, selected: Option<&Entry>, area: &Rc
     let args_info_par = Paragraph::new(args_info)
         .block(Block::default().padding(Padding::new(2, 2, 0, 0)))
         .alignment(Alignment::Right);
-    frame.render_widget(args_info_par, area[2]);
+    frame.render_widget(args_info_par, area[0]);
 
     // Dev container path
     let dc_path = selected.map_or_else(String::new, |entry| {
@@ -242,79 +587,13 @@ fn render_additional_info(frame: &mut Frame, selected: Option<&Entry>, area: &Rc
         Style::default().fg(Color::DarkGray),
     );
     let dc_path_info_par = Paragraph::new(dc_path_info).block(Block::default());
-    frame.render_widget(dc_path_info_par, area[3]);
+    frame.render_widget(dc_path_info_par, area[1]);
 }
 
-/// Main render function
-fn render(frame: &mut Frame, app: &mut UI, rows: Vec<Row>) {
-    // Setup crossterm UI layout & style
-    let area = Layout::default()
-        .constraints(
-            [
-                Constraint::Percentage(100),
-                Constraint::Min(1),
-                Constraint::Min(1),
-                Constraint::Min(1),
-            ]
-            .as_ref(),
-        )
-        .horizontal_margin(1)
-        .split(frame.area());
-
-    // Calculate the longest workspace and dev container names
-    let longest_ws_name =
-        calculate_longest_name(&app.tracker.history, |s| &s.workspace_name, 20, 9, 60);
-    let longest_dc_name = calculate_longest_name(
-        &app.tracker.history,
-        |s| s.dev_container_name.as_deref().unwrap_or_default(),
-        20,
-        9,
-        60,
-    );
-
-    // Render the main table
-    render_table(frame, app, rows, area[0], longest_ws_name, longest_dc_name);
-
-    // Get the selected entry
-    let selected = app
-        .tracker
-        .history
-        .iter()
-        .nth(app.state.selected().unwrap_or(0));
-
-    // Render status area
-    let status_area: Rc<[Rect]> = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)].as_ref())
-        .split(area[1]);
-    render_status_area(frame, selected, &status_area);
-
-    // Render additional info like args and dev container path
-    render_additional_info(frame, selected, &area);
-}
-
-/// Calculates the longest name from a history vector
-fn calculate_longest_name<'a, F>(
-    history: &'a History,
-    extractor: F,
-    default: u16,
-    min: usize,
-    max: usize,
-) -> u16
-where
-    F: Fn(&'a Entry) -> &'a str,
-{
-    u16::try_from(
-        history
-            .iter()
-            .map(|entry| extractor(entry).len())
-            .max()
-            .unwrap_or(default.into())
-            .clamp(min, max),
-    )
-    .unwrap_or(default)
-}
-/// Maps an option to a string, using a default value if the option is `None`
-fn map_or_default<T, F: Fn(T) -> String>(option: Option<T>, default: &str, f: F) -> String {
-    option.map_or(default.to_string(), f)
+fn add_num_opt(o1: Option<i64>, o2: Option<i64>) -> Option<i64> {
+    match (o1, o2) {
+        (Some(n1), Some(n2)) => Some(n1 + n2),
+        (Some(n), None) | (None, Some(n)) => Some(n),
+        _ => None,
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -633,6 +633,9 @@ fn render_additional_info(frame: &mut Frame, selected: Option<&Entry>, area: [Re
     frame.render_widget(dc_path_info_par, area[1]);
 }
 
+/// Adds two optional [`i64`]s.
+///
+/// If at least one of the inputs is [`Option::Some`] then the result will also be [`Option::Some`].
 fn add_num_opt(o1: Option<i64>, o2: Option<i64>) -> Option<i64> {
     match (o1, o2) {
         (Some(n1), Some(n2)) => Some(n1 + n2),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -579,7 +579,7 @@ fn render_status_area(frame: &mut Frame, selected: Option<&Entry>, status_area: 
     frame.render_widget(additional_info_par, status_area[1]);
 
     let instruction = Span::styled(
-        "Press x to remove the selected item. Press q to quit.",
+        "Press x to remove the selected item. Press tab to switch focus. Press q to quit.",
         Style::default().fg(Color::Gray),
     );
     let instructions_par = Paragraph::new(instruction)


### PR DESCRIPTION
Adds a search bar to the list which enables fuzzy searching for:
- container name
- worspace name & path

## Implementation

This was a bit of a more involved change than initially thought.

To have persistent selections (e.g. a few entries are hidden after a search but the cursor is still selecting the previously selected entry even if its position has changed), uuid for Entries where introduced. These allow persistent addressing independent of index.

A (very basic) focus system was implemented to allow switching between search and select mode (currently via tab).

The input handling was streamlined to not directly influence the state of the app, instead `Actions` are returned which are then processed in the main app update loop. 
