### PR TITLE
feat: Remove focus implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,9 +89,9 @@ fn main() -> Result<()> {
                 last_opened: Utc::now(),
             });
         }
-        opts::Commands::Recent { focus } => {
+        opts::Commands::Recent => {
             // Get workspace from user selection
-            let res = ui::start(&mut tracker, focus)?;
+            let res = ui::start(&mut tracker)?;
             if let Some(entry) = res {
                 let ws = Workspace::from_path(&entry.workspace_path)?;
                 let ws_name = ws.name.clone();

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -2,7 +2,7 @@ use std::{ffi::OsString, path::PathBuf};
 
 use clap::{command, Parser, Subcommand};
 
-use crate::{launch::ContainerStrategy, ui::Focus};
+use crate::launch::ContainerStrategy;
 
 /// Main CLI arguments
 #[derive(Parser, Debug)]
@@ -58,8 +58,5 @@ pub(crate) enum Commands {
     },
     /// Opens an interactive list of recently used workspaces.
     #[clap(alias = "ui")]
-    Recent {
-        #[arg(value_enum, short, long, default_value_t = Focus::Select, ignore_case = true)]
-        focus: Focus,
-    },
+    Recent,
 }


### PR DESCRIPTION
Removes the component focus implementation added with #135. Instead the search and select are always "focused" and the inputs to the components are differentiated by modifiers.

All single keybindings from before (e.g. `q` for quit) are now only activated if `CTRL` is also pressed any normal input is directly send to the search bar.