### PR TITLE
fix: using `localWorkspaceFolderBasename` in `workspaceFolder`

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -86,7 +86,7 @@ impl DevContainer {
 
         // Replace ${localWorkspaceFolder} with the full workspace path
         // This defaults to /workspaces/<workspace_name> for consistency
-        let default_workspace = format!("/workspaces/{}", workspace_name);
+        let default_workspace = format!("/workspaces/{workspace_name}");
         result = result.replace("${localWorkspaceFolder}", &default_workspace);
 
         result


### PR DESCRIPTION
Encountered this issue recently (#171) as I like to use multiple git worktree in devcontainer while working on multiple features.

Not sure if there are any other variables used in `workspaceFolder`, but this works for `localWorkspaceFolderBasename` and `localWorkspaceFolder`.

Thanks to your tool I can finally open multiple devcontainer without having to first open the project. Not sure why Microsoft never added this feature to vscode.