### PR TITLE
fix: keep most recent entries in history retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2117,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2477,7 @@ dependencies = [
  "ratatui-textarea",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ walkdir = "2.5.0"
 wslpath2 = "0.1.3"
 ratatui-textarea = "0.9.0"
 nucleo-matcher = "0.3.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/history.rs
+++ b/src/history.rs
@@ -248,10 +248,10 @@ mod tests {
         // The oldest entry should be removed, the newest should be kept
         for i in 0..40 {
             let entry = Entry {
-                workspace_name: format!("workspace_{}", i),
+                workspace_name: format!("workspace_{i}"),
                 dev_container_name: None,
                 config_name: None,
-                workspace_path: PathBuf::from(format!("/path/to/workspace_{}", i)),
+                workspace_path: PathBuf::from(format!("/path/to/workspace_{i}")),
                 config_path: None,
                 behavior: Behavior {
                     strategy: ContainerStrategy::Detect,
@@ -284,8 +284,7 @@ mod tests {
                 .unwrap();
             assert!(
                 num >= 5,
-                "Entry workspace_{} should have been removed (only keeping most recent 35)",
-                num
+                "Entry workspace_{num} should have been removed (only keeping most recent 35)"
             );
         }
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -213,15 +213,80 @@ impl Tracker {
         )?;
         let file = File::create(self.path)?;
 
-        // since history is sorted, we can remove the first entries to limit the max size
-        let entries: Vec<Entry> = self
-            .history
-            .into_entries()
-            .into_iter()
-            .take(MAX_HISTORY_ENTRIES)
-            .collect();
+        // Sort entries by last_opened (most recent first), then keep only the newest MAX_HISTORY_ENTRIES
+        let mut entries: Vec<Entry> = self.history.into_entries();
+        entries.sort_by_key(|b| std::cmp::Reverse(b.last_opened));
+        entries.truncate(MAX_HISTORY_ENTRIES);
 
         serde_json::to_writer_pretty(file, &entries)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::launch::ContainerStrategy;
+    use chrono::Duration;
+
+    #[test]
+    fn test_store_keeps_most_recent_entries() {
+        use tempfile::TempDir;
+
+        // Create a temporary directory for the test
+        let temp_dir = TempDir::new().unwrap();
+        let history_path = temp_dir.path().join("history.json");
+
+        // Create more entries than MAX_HISTORY_ENTRIES
+        let now = Utc::now();
+        let mut tracker = Tracker {
+            path: history_path.clone(),
+            history: History::default(),
+        };
+
+        // Add 40 entries (more than MAX_HISTORY_ENTRIES = 35)
+        // The oldest entry should be removed, the newest should be kept
+        for i in 0..40 {
+            let entry = Entry {
+                workspace_name: format!("workspace_{}", i),
+                dev_container_name: None,
+                config_name: None,
+                workspace_path: PathBuf::from(format!("/path/to/workspace_{}", i)),
+                config_path: None,
+                behavior: Behavior {
+                    strategy: ContainerStrategy::Detect,
+                    args: vec![],
+                    command: "code".to_string(),
+                },
+                last_opened: now - Duration::seconds((39 - i) * 60), // oldest first
+            };
+            tracker.history.insert(entry);
+        }
+
+        // Store the history
+        tracker.store().unwrap();
+
+        // Load it back
+        let reloaded = Tracker::load(&history_path).unwrap();
+        let entries = reloaded.history.into_entries();
+
+        // Should have exactly MAX_HISTORY_ENTRIES
+        assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
+
+        // All entries should be from the most recent ones (workspace_5 through workspace_39)
+        // The oldest 5 entries (workspace_0 through workspace_4) should be removed
+        for entry in &entries {
+            let num: usize = entry
+                .workspace_name
+                .strip_prefix("workspace_")
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert!(
+                num >= 5,
+                "Entry workspace_{} should have been removed (only keeping most recent 35)",
+                num
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed history tracker to sort entries by `last_opened` descending before truncating to `MAX_HISTORY_ENTRIES`, so the most recently used entries are retained
- Previously, `.take(MAX_HISTORY_ENTRIES)` was called on entries from `into_entries()` which had no guaranteed order, causing arbitrary entries to be kept

## Test plan
- [ ] `cargo test test_store_keeps_most_recent_entries` passes (1/1)
- [ ] Test creates 40 entries exceeding `MAX_HISTORY_ENTRIES=35` and verifies the 5 oldest are dropped
- [ ] `cargo clippy` clean, all existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix history retention to keep the most recently opened entries by sorting by `last_opened` before truncation. Previously, unsorted entries caused random items to be kept when exceeding the limit.

- **Bug Fixes**
  - Sort entries by `last_opened` (desc) and then truncate to `MAX_HISTORY_ENTRIES`.
  - Add test `test_store_keeps_most_recent_entries` (40 entries; oldest 5 dropped).
  - Resolve clippy `uninlined_format_args` lints.

- **Dependencies**
  - Add dev-dependency `tempfile` for isolated file-system tests.

<sup>Written for commit 54575c96bcd07a7fcf05477fac1b3a6de549260b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

